### PR TITLE
Add VGA 640x480 upscaling and update filter widths

### DIFF
--- a/cam/digital_cam_top.v
+++ b/cam/digital_cam_top.v
@@ -330,7 +330,9 @@ module digital_cam_top (
     // ============================================================================
     // 1차 가우시안 블러
     wire [7:0] gray_blur;
-    gaussian_3x3_gray8 gaussian_gray_inst (
+    gaussian_3x3_gray8 #(
+        .IMG_WIDTH(640)
+    ) gaussian_gray_inst (
         .clk(clk_25_vga),
         .enable(1'b1),
         .pixel_in(gray_value),
@@ -346,7 +348,10 @@ module digital_cam_top (
     // 소벨 엣지 검출 (1차 가우시안 지연에 맞춘 타이밍)
     wire [16:0] rdaddress_gauss = rdaddress_delayed[GAUSS_LAT];
     wire activeArea_gauss = activeArea_delayed[GAUSS_LAT];
-    sobel_3x3_gray8 sobel_inst (
+    sobel_3x3_gray8 #(
+        .IMG_WIDTH(640),
+        .IMG_HEIGHT(480)
+    ) sobel_inst (
         .clk(clk_25_vga),
         .enable(1'b1),
         .pixel_in(gray_blur),  // 1차 가우시안 출력
@@ -359,7 +364,9 @@ module digital_cam_top (
     );
 
     // 캐니 엣지 검출 (1차 가우시안 지연에 맞춘 타이밍)
-    canny_3x3_gray8 canny_inst (
+    canny_3x3_gray8 #(
+        .IMG_WIDTH(640)
+    ) canny_inst (
         .clk(clk_25_vga),
         .enable(filter_ready),  // 1차 가우시안 ready
         .pixel_in(gray_blur),   // 1차 가우시안 출력
@@ -405,11 +412,11 @@ module digital_cam_top (
     );
 
     // VGA 컨트롤러
-    VGA vga_inst (
-        .CLK25(clk_25_vga), 
-        .pixel_data(rddata), 
+    vga_640 vga_inst (
+        .CLK25(clk_25_vga),
+        .pixel_data(rddata),
         .clkout(vga_CLK),
-        .Hsync(hsync_raw), 
+        .Hsync(hsync_raw),
         .Vsync(vsync_raw),
         .Nblank(vga_blank_N_raw), 
         .Nsync(vga_sync_N_raw),

--- a/cam/gaussian_3x3_gray8.v
+++ b/cam/gaussian_3x3_gray8.v
@@ -28,7 +28,10 @@ module gaussian_3x3_gray8 #(
     wire active_fall = ~active_area & active_prev;     // end of active line
 
     // Position within active window
-    reg [8:0] col = 9'd0;   // 0..IMG_WIDTH-1
+    localparam integer COL_BITS = (IMG_WIDTH <= 256) ? 8 :
+                                   (IMG_WIDTH <= 512) ? 9 : 10;
+
+    reg [COL_BITS-1:0] col = {COL_BITS{1'b0}};   // 0..IMG_WIDTH-1
     reg [9:0] row = 10'd0;  // counts active lines, saturates
 
     // Two line buffers (previous two lines)
@@ -58,7 +61,7 @@ module gaussian_3x3_gray8 #(
     always @(posedge clk) begin
         if (vsync_fall) begin
             // start of frame: reset position and taps
-            col <= 9'd0;
+            col <= {COL_BITS{1'b0}};
             row <= 10'd0;
             {cur_0,cur_1,cur_2} <= 24'd0;
             {l1_0,l1_1,l1_2}    <= 24'd0;
@@ -69,7 +72,7 @@ module gaussian_3x3_gray8 #(
         end else if (enable) begin
             if (active_rise) begin
                 // new active line: reset horizontal taps only
-                col <= 9'd0;
+                col <= {COL_BITS{1'b0}};
                 {cur_0,cur_1,cur_2} <= 24'd0;
                 {l1_0,l1_1,l1_2}    <= 24'd0;
                 {l2_0,l2_1,l2_2}    <= 24'd0;
@@ -97,9 +100,9 @@ module gaussian_3x3_gray8 #(
 
             // pipeline-valid alignment
             active_d1       <= active_area;
-            window_valid_d1 <= (row >= 10'd2) && (col >= 9'd2) && active_area;
+            window_valid_d1 <= (row >= 10'd2) && (col >= 2) && active_area;
             pixel_in_d1     <= pixel_in;
-            border_d1       <= active_area && ((row < 10'd2) || (col < 9'd2));
+            border_d1       <= active_area && ((row < 10'd2) || (col < 2));
         end
     end
 

--- a/cam/vga_640.v
+++ b/cam/vga_640.v
@@ -1,0 +1,95 @@
+// VGA controller with 2x up-scaling (nearest neighbour) from 320x240 source
+// to 640x480 output.  Generates 640x480@60Hz timing while mapping display
+// coordinates to the underlying 320x240 frame buffer.  For each display pixel,
+// the corresponding source coordinate is calculated as (x>>1, y>>1) so the
+// same pixel/line is repeated twice horizontally and vertically.  The
+// pixel_address therefore follows the pattern 0,0,1,1,... for each line and
+// repeats the same line address for two consecutive VGA lines.  The activeArea
+// output asserts during the entire 640x480 visible region so downstream image
+// processing modules must be configured for IMG_WIDTH=640 and IMG_HEIGHT=480.
+module vga_640 (
+    input  wire        CLK25,          // 25 MHz pixel clock
+    input  wire [15:0] pixel_data,     // unused but kept for interface match
+    output wire        clkout,         // pixel clock to DAC
+    output reg         Hsync,
+    output reg         Vsync,
+    output wire        Nblank,
+    output reg         activeArea,     // asserted during 640x480 visible area
+    output wire        Nsync,
+    output reg [16:0]  pixel_address   // frame-buffer read address (RGB565)
+);
+
+    // 640x480@60Hz timing parameters (same as original VGA module)
+    localparam integer HM = 799;  // horizontal total - 1
+    localparam integer HD = 640;  // horizontal display
+    localparam integer HF = 16;   // horizontal front porch
+    localparam integer HB = 48;   // horizontal back porch
+    localparam integer HR = 96;   // horizontal sync pulse width
+
+    localparam integer VM = 524;  // vertical total - 1
+    localparam integer VD = 480;  // vertical display
+    localparam integer VF = 10;   // vertical front porch
+    localparam integer VB = 33;   // vertical back porch
+    localparam integer VR = 2;    // vertical sync pulse width
+
+    // Horizontal/vertical counters
+    reg [9:0] Hcnt = 10'd0;
+    reg [9:0] Vcnt = 10'd0;
+
+    // Increment timing counters
+    always @(posedge CLK25) begin
+        if (Hcnt == HM) begin
+            Hcnt <= 10'd0;
+            if (Vcnt == VM)
+                Vcnt <= 10'd0;
+            else
+                Vcnt <= Vcnt + 1'b1;
+        end else begin
+            Hcnt <= Hcnt + 1'b1;
+        end
+    end
+
+    // VGA sync generation (active low pulses)
+    always @(posedge CLK25) begin
+        if (Hcnt >= (HD + HF) && Hcnt <= (HD + HF + HR - 1))
+            Hsync <= 1'b0;
+        else
+            Hsync <= 1'b1;
+    end
+
+    always @(posedge CLK25) begin
+        if (Vcnt >= (VD + VF) && Vcnt <= (VD + VF + VR - 1))
+            Vsync <= 1'b0;
+        else
+            Vsync <= 1'b1;
+    end
+
+    assign Nsync = 1'b1;                         // not used by ADV7123
+    wire video_active = (Hcnt < HD) && (Vcnt < VD);
+    assign Nblank = video_active;                 // assert during visible area
+    assign clkout = CLK25;
+
+    // Maintain activeArea flag
+    always @(posedge CLK25) begin
+        activeArea <= video_active;
+    end
+
+    // Compute source coordinates (nearest neighbour doubling)
+    wire [9:0] disp_x = (Hcnt < HD) ? Hcnt : 10'd0;
+    wire [9:0] disp_y = (Vcnt < VD) ? Vcnt : 10'd0;
+
+    wire [8:0] src_x = disp_x[9:1];      // divide by 2 (0..319)
+    wire [8:0] src_y = disp_y[9:1];      // divide by 2 (0..239)
+
+    wire [16:0] line_base = {src_y, 8'b0} + {src_y, 6'b0}; // src_y*256 + src_y*64
+    wire [16:0] addr_next = line_base + src_x;
+
+    // Register the computed address (synchronous RAM latency compensation)
+    always @(posedge CLK25) begin
+        if (!video_active)
+            pixel_address <= 17'd0;
+        else
+            pixel_address <= addr_next;
+    end
+
+endmodule


### PR DESCRIPTION
## Summary
- add a dedicated vga_640 controller that doubles the 320x240 frame buffer to a 640x480 display
- retune gaussian, sobel, and canny pipelines to support 640-pixel line buffers and update instantiations

## Testing
- not run (hardware-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e4e74d28248327a25fb8c97f5cce39